### PR TITLE
variableize preseed update policy

### DIFF
--- a/preseed/README.md
+++ b/preseed/README.md
@@ -25,5 +25,6 @@ The templates use some Host Parameters to contol the flow of the template. These
 * `enable-saltstack-repo`: Add the SaltStack APT repo to the APT sources during install (default: `false`)
 * `salt_master`: SaltStack Master (default: empty)
 * `salt_grains`: Salt client specific information, like facter (default: empty)
+* `preseed-update-policy`: Preseed policy for applying updates to running systems. Can be `none`, `unattended-upgrades`, or `landscape`. (default: unattended-upgrades)
 
 Detailed description is available at https://www.debian.org/releases/stable/amd64/apbs04.html.en

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -113,7 +113,7 @@ tasksel tasksel/first multiselect minimal, ssh-server, openssh-server
 
 # Install some base packages
 d-i pkgsel/include string <%= puppet_package %> <%= salt_package %> lsb-release
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select <%= @host.params['preseed-update-policy'] || 'unattended-upgrades' %>
 
 popularity-contest popularity-contest/participate boolean false
 


### PR DESCRIPTION
- Change preseed update policy to default to `unattended-upgrades` but allow overrides
- Update preseed readme to document feature
- closes GH-324