### PR TITLE
Patches for building a server against a frozen mirror.

### DIFF
--- a/preseed/README.md
+++ b/preseed/README.md
@@ -29,5 +29,7 @@ The templates use some Host Parameters to contol the flow of the template. These
 * `preseed-live-installer`: Informs the installer that the installation source is from an iso. Can be `true` or `false`. (defaults: notset/false)
 * `preseed-kernel-image`: Specify the kernel-image to install. Ex: `linux-image-generic-lts-xenial` or `linux-image-4.4.0-34-generic`. (default: empty)
 * `preseed-post-install-upgrade`: Upgrade Debian post installation. Can be `none`, `safe-upgrade`, or `full-upgrade`. (default: none)
+* `disable-ubuntu-security-repo`: Disable the Ubuntu security repo. Can be `true` or `false`.
+* `disable-ubuntu-backports-repo`: Disable the Ubuntu backports repo. Can be `true` or false`.
 
 Detailed description is available at https://www.debian.org/releases/stable/amd64/apbs04.html.en

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -13,6 +13,7 @@ oses:
   salt_enabled = @host.params['salt_master'] ? true : false
   os_major = @host.operatingsystem.major.to_i
   squeeze_or_older = (@host.operatingsystem.name == 'Debian' && os_major <= 6)
+  xenial_or_newer = (@host.operatingsystem.name == 'Ubuntu' && os_major >= 14)
 %>
 # Locale
 d-i debian-installer/locale string <%= @host.params['lang'] || 'en_US' %>
@@ -92,6 +93,13 @@ d-i passwd/make-user boolean false
 user-setup-udeb passwd/make-user boolean false
 
 <% repos = 0 %>
+<% if xenial_or_newer && (puppet_enabled || salt_enabled) -%>
+d-i apt-setup/local<%= repos %>/repository string \
+      deb http://<%= @preseed_server %>/<%= @preseed_path %> <%= @host.operatingsystem.release_name %> restricted
+d-i apt-setup/local<%= repos %>/comment string Xenial Workaround
+d-i apt-setup/local<%= repos %>/source boolean false
+<% repos += 1 -%>
+<% end -%>
 <% if puppet_enabled -%>
 <% if @host.param_true?('enable-puppetlabs-repo') -%>
 # Puppetlabs products
@@ -137,6 +145,13 @@ d-i apt-setup/local<%= repos %>/key string http://keyserver.ubuntu.com/pks/looku
 <% end -%>
 <% else -%>
 <% salt_package = '' -%>
+<% end -%>
+
+<% if @host.param_true?('disable-ubuntu-security-repo') -%>
+d-i apt-setup/services-select-ubuntu multiselect none
+<% end -%>
+<% if @host.param_true?('disable-ubuntu-backports-repo') -%>
+d-i apt-setup/backports boolean false
 <% end -%>
 
 # Install minimal task set (see tasksel --task-packages minimal)


### PR DESCRIPTION
  * Add workaround for xenial gpg errors for the first apt-setup/local0 repo. https://bugs.launchpad.net/ubuntu/+source/debian-installer/+bug/1566757
  * Add in variable for disabling the security repo.
  * Add in variable for disabling the backports repo.